### PR TITLE
fix connection connection initialization handling

### DIFF
--- a/aiomqtt/client.py
+++ b/aiomqtt/client.py
@@ -696,12 +696,12 @@ class Client:
                 self._properties,
             )
             _set_client_socket_defaults(self._client.socket(), self._socket_options)
+            await self._wait_for(self._connected, timeout=None)
         # Convert all possible paho-mqtt Client.connect exceptions to our MqttError
         # See: https://github.com/eclipse/paho.mqtt.python/blob/v1.5.0/src/paho/mqtt/client.py#L1770
-        except (OSError, mqtt.WebsocketConnectionError) as exc:
+        except (OSError, mqtt.WebsocketConnectionError, MqttConnectError) as exc:
             self._lock.release()
             raise MqttError(str(exc)) from None
-        await self._wait_for(self._connected, timeout=None)
         # Reset `_disconnected` if it's already in completed state after connecting
         if self._disconnected.done():
             self._disconnected = asyncio.Future()


### PR DESCRIPTION
Connection errors in __aenter__() which happen while _wait_for(selt._conected,...) were not catched, leaving a stale _lock behind, which made client non reusable.

Pull waiting for connected event into try/except block, so client is reusable in event of an error while trying to connect.

fixes #269